### PR TITLE
Adds the ability to specify World Tracking vs. Orientation Tracking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "ARCL",
-            targets: ["ARKit-CoreLocation"]),
+            targets: ["ARKit-CoreLocation"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.

--- a/Sources/ARKit-CoreLocation/SceneLocationView.swift
+++ b/Sources/ARKit-CoreLocation/SceneLocationView.swift
@@ -92,11 +92,15 @@ open class SceneLocationView: ARSCNView {
 
     // MARK: Setup
 
-    /// Default initialization, allows you specify the type of AR Tracking to use (or default to World Tracking).
+    /// This initializer allows you to specify the type of tracking configuration (defaults to world tracking) as well as
+    /// some other optional values.
     ///
-    /// - Parameter trackingType: The type of AR Tracking to use.
-    public convenience init(trackingType: ARTrackingType = .worldTracking) {
-        self.init(frame: .zero, options: nil)
+    /// - Parameters:
+    ///   - trackingType: The type of AR Tracking configuration (defaults to world tracking).
+    ///   - frame: The CGRect for the frame (defaults to .zero).
+    ///   - options: The rendering options for the `SCNView`.
+    public convenience init(trackingType: ARTrackingType = .worldTracking, frame: CGRect = .zero, options: [String: Any]? = nil) {
+        self.init(frame: frame, options: options)
         self.arTrackingType = trackingType
     }
 
@@ -158,6 +162,7 @@ public extension SceneLocationView {
         case .worldTracking:
             let configuration = ARWorldTrackingConfiguration()
             configuration.planeDetection = .horizontal
+            configuration.worldAlignment = orientToTrueNorth ? .gravityAndHeading : .gravity
             session.run(configuration)
 
         case .orientationTracking:

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 - 1.2.1
+    - [PR #198 - Adds support for AR Orientation Tracking](https://github.com/ProjectDent/ARKit-CoreLocation/pull/198)
     - [PR #193 - Adds support for Swift Package Manager](https://github.com/ProjectDent/ARKit-CoreLocation/pull/193)
 - 1.2.0 
     - [PR #185 - Custom boxes for directions](https://github.com/ProjectDent/ARKit-CoreLocation/pull/185/files)


### PR DESCRIPTION
### Background
@Pilot-Marc enlightened me to some alternative use cases that have different needs for the tracking configuration.  To accommodate this, I've augmented his PR to add an enum value to the initializer for the `SceneLocationView` that defaults to World Tracking, but lets you specify Orientation Tracking if you so desire.

### Breaking Changes
This change should be backwards compatible with what's in place now, but also allow for Marc's use cases.

### Meta
- Tied to Version Release(s): 1.2.1

### Checklist

- [ ] Appropriate label has been added to this PR (i.e., Bug, Enhancement, etc.).
- [x] Documentation has been added to all `open`, and `public` scoped methods and properties.
- [x] Changelog has been updated
- [ ] Tests have have been added to all new features. (not a requirement, but helpful)
- [ ] N/A ~Image/GIFs have been added for all UI related changed.~